### PR TITLE
Fix filename issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mira-download-manager",
-   "version": "1.0.1",
+   "version": "1.0.2",
    "description": "manage download of video files",
    "devDependencies": {
       "@types/amqplib": "^0.8.2",

--- a/src/service/FileManageService.ts
+++ b/src/service/FileManageService.ts
@@ -70,7 +70,12 @@ export class FileManageService {
         }
     }
 
+    /**
+     * add a random hash suffix, and replace reserved character ',' with '_'
+     * @param filename
+     */
     public static processFilename(filename: string): string {
+        filename = filename.replace(/,/ig, '_');
         const randomHash = nanoid(5);
         const e = extname(filename);
         let b = basename(filename, e);


### PR DESCRIPTION
Some filename contains comma character which will result issue in the Albireo rpc interface (the file name list is separated with comma)

Replace the comma with underscore in filename