### PR TITLE
Error handling in resendFinishMessage API

### DIFF
--- a/src/api-service/controller/DownloadController.ts
+++ b/src/api-service/controller/DownloadController.ts
@@ -31,12 +31,15 @@ import { DownloadJob } from '../../entity/DownloadJob';
 import { inject } from 'inversify';
 import { ResponseWrapper, TYPES } from '@irohalab/mira-shared';
 import { DownloadService } from '../../service/DownloadService';
+import { getStdLogger } from '../../utils/Logger';
 
 type Operation = { action: 'pause' | 'resume' | 'delete' };
 
 const OP_PAUSE = 'pause';
 const OP_RESUME = 'resume';
 const OP_DELETE = 'delete';
+
+const logger = getStdLogger();
 
 @controller('/download')
 export class DownloadController implements interfaces.Controller {
@@ -100,7 +103,16 @@ export class DownloadController implements interfaces.Controller {
         const job = await this._database.getJobRepository(true).findOne({ id: jobId});
         if (job) {
             console.log(job);
-            await this._downloadService.downloadComplete(job);
+            try {
+                await this._downloadService.downloadComplete(job);
+            } catch (ex) {
+                logger.error(ex);
+                return {
+                    data: ex,
+                    message: 'error while trying to resent message',
+                    status: 0
+                };
+            }
             return {
                 data: null,
                 message: 'message resent!',


### PR DESCRIPTION
send the error message back to client when there is an exception in DownloadService.download() method.