### PR TITLE
Update nanoid to v3, Dockerfile Node version, and default storage type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17 AS base
+FROM node:20-bullseye AS base
 WORKDIR /app
 
 FROM base AS dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "mira-download-manager",
-   "version": "1.4.0",
+   "version": "1.5.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "mira-download-manager",
-         "version": "1.4.0",
+         "version": "1.5.0",
          "dependencies": {
             "@aws-sdk/client-s3": "^3.821.0",
             "@irohalab/mira-shared": "4.2.2",
@@ -21,7 +21,7 @@
             "inversify": "^6.0.3",
             "inversify-express-utils": "^6.5.0",
             "js-yaml": "4.1.1",
-            "nanoid": "5.0.9",
+            "nanoid": "3.3.11",
             "parse-torrent": "^9.1.4",
             "pg": "^8.4.0",
             "pino": "^7.6.2",
@@ -5137,9 +5137,9 @@
          "license": "MIT"
       },
       "node_modules/nanoid": {
-         "version": "5.0.9",
-         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
-         "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
+         "version": "3.3.11",
+         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+         "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
          "funding": [
             {
                "type": "github",
@@ -5148,10 +5148,10 @@
          ],
          "license": "MIT",
          "bin": {
-            "nanoid": "bin/nanoid.js"
+            "nanoid": "bin/nanoid.cjs"
          },
          "engines": {
-            "node": "^18 || >=20"
+            "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
          }
       },
       "node_modules/negotiator": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "inversify": "^6.0.3",
       "inversify-express-utils": "^6.5.0",
       "js-yaml": "4.1.1",
-      "nanoid": "5.0.9",
+      "nanoid": "3.3.11",
       "parse-torrent": "^9.1.4",
       "pg": "^8.4.0",
       "pino": "^7.6.2",

--- a/src/utils/ConfigManagerImpl.ts
+++ b/src/utils/ConfigManagerImpl.ts
@@ -76,7 +76,7 @@ export class ConfigManagerImpl implements ConfigManager {
     }
 
     public storageType(): 'S3' | 'Filesystem' {
-        return this._config.storage_type;
+        return this._config.storage_type ?? 'Filesystem';
     }
 
     public s3Config(): S3ClientConfig {


### PR DESCRIPTION
This pull request updates dependencies and improves configuration defaults to enhance compatibility and reliability. The most important changes are:

**Dependency Updates:**

* Updated the base image in the `Dockerfile` from `node:17` to `node:20-bullseye` to ensure compatibility with newer Node.js features and improved security.
* Downgraded the `nanoid` package version from `5.0.9` to `3.3.11` in `package.json`, to support CommonJS

**Configuration Improvements:**

* Modified the `storageType()` method in `ConfigManagerImpl` (`src/utils/ConfigManagerImpl.ts`) to default to `'Filesystem'` if `storage_type` is not set in the configuration, improving robustness against missing config values.